### PR TITLE
Expand support to MacOS 12.3

### DIFF
--- a/electron_app/vue.config.js
+++ b/electron_app/vue.config.js
@@ -23,9 +23,9 @@ module.exports = {
                     "hardenedRuntime": true,
                     "entitlements": "build/entitlements.mac.plist",
                     "entitlementsInherit": "build/entitlements.mac.plist",
-                    "minimumSystemVersion": "12.5.1",
+                    "minimumSystemVersion": "12.3",
                     "extendInfo": {
-                        "LSMinimumSystemVersion": "12.5.1"
+                        "LSMinimumSystemVersion": "12.3"
                     } , 
                     "target": {
                         "target": "dmg",


### PR DESCRIPTION
### Problem
The app  build is not running on ealier MacOS versions with M1. Building from source takes too much time. 
Tested on MacOS Monterey 12.3.

### Solution
Expand support for Mac folks who haven't received an 12.5.1 update 🙂 

This resolves #11. 