### PR TITLE
added seed and prompt to filename when saving image

### DIFF
--- a/electron_app/src/components/History.vue
+++ b/electron_app/src/components/History.vue
@@ -5,15 +5,13 @@
             <div v-for="history_box in Object.values(app_state.history)" :key="history_box.key" style="clear: both;">
             
                 <div @click="delete_hist(history_box.key)" style="float:right; margin-top: 10px;"  class="l_button">Delete</div>
-                <p style="background-color: rgba(0, 0, 0, 0.05); padding :12px; border-radius: 5px; max-width: calc(100vw - 200px );">{{history_box.promt}}</p>
-            
+                <p class="history_box_info">{{history_box.seed}}<br/>{{history_box.prompt}}</p>
                 
-                
-                <div v-for="img in history_box.imgs" :key="img" style="height:230px; float:left; margin-right: 10px; margin-bottom: 30px;">
+                <div v-for="img in history_box.imgs" :key="img" class="history_box">
                     
                     <img  class="gal_img" v-if="img" :src="'file://' + img" style="height:100%">
                     <br>
-                    <div @click="save_image(img)" class="l_button">Save Image</div>
+                    <div @click="save_image(img, history_box.prompt, history_box.seed)" class="l_button">Save Image</div>
                     <br>
                 
                 </div>
@@ -55,11 +53,11 @@ export default {
             Vue.delete( this.app_state.history , k );
         }, 
 
-        save_image(generated_image){
+        save_image(generated_image, prompt, seed){
             if(!generated_image)
                 return;
             generated_image = generated_image.split("?")[0];
-            let out_path = window.ipcRenderer.sendSync('save_dialog', '');
+            let out_path = window.ipcRenderer.sendSync('save_dialog', prompt, seed);
             if(!out_path)
                 return
             let org_path = generated_image.replaceAll("file://" , "")
@@ -72,4 +70,16 @@ export default {
 <style>
 </style>
 <style scoped>
+.history_box_info {
+    background-color: rgba(0, 0, 0, 0.05);
+    padding :12px;
+    border-radius: 5px;
+    max-width: calc(100vw - 200px );
+}
+.history_box {
+    height:230px;
+    float:left;
+    margin-right: 10px;
+    margin-bottom: 30px;
+}
 </style>

--- a/electron_app/src/components/ImgGenerate.vue
+++ b/electron_app/src/components/ImgGenerate.vue
@@ -16,7 +16,7 @@
 
                 <div v-if="stable_diffusion.is_input_avail" class="content_toolbox" style="margin-top:10px; margin-bottom:-10px;">
                     
-                    <div class="l_button button_medium button_colored" style="float:right ; " @click="generete_from_prompt">Generate</div>
+                    <div class="l_button button_medium button_colored" style="float:right ; " @click="generate_from_prompt">Generate</div>
 
                     <!-- <div style="float:right;"  >
                         <div class="l_button" @click="is_adv_options = !is_adv_options">Advanced options</div>
@@ -139,7 +139,7 @@
                 <center>
                     <img  class="gal_img" v-if="generated_images[0]" :src="'file://' + generated_images[0]" style=" height: calc(100vh - 380px ); margin-top: 60px;">
                     <br>
-                    <div @click="save_image(generated_images[0])" class="l_button">Save Image</div>
+                    <div @click="save_image(generated_images[0], prompt, seed)" class="l_button">Save Image</div>
                 </center>
             </div>
             
@@ -151,7 +151,7 @@
                         <center>
                             <img  class="gal_img" v-if="img" :src="'file://' + img" style="max-width:85%">
                             <br>
-                            <div @click="save_image(img)" class="l_button">Save Image</div>
+                            <div @click="save_image(img, prompt, seed)" class="l_button">Save Image</div>
                         </center>
                     </b-col>
                         
@@ -220,7 +220,7 @@ export default {
         
     },
     methods: {
-        generete_from_prompt(){
+        generate_from_prompt(){
             let params = {
                 prompt : this.prompt , 
                 W : Number(this.img_w) , 
@@ -247,7 +247,7 @@ export default {
                     that.generated_images.push(img_path);
 
                     if(!(that.app_state.history[history_key]))
-                        Vue.set(that.app_state.history, history_key , {"promt":that.prompt , "key":history_key , "imgs" : []});
+                        Vue.set(that.app_state.history, history_key , {"prompt":that.prompt , "seed": that.seed, "key":history_key , "imgs" : []});
                     
                     that.app_state.history[history_key].imgs.push(img_path)
 
@@ -282,12 +282,13 @@ export default {
             this.prompt += ", " + tag;
         },
 
-        save_image(generated_image){
+        save_image(generated_image, prompt, seed){
             if(!generated_image)
                 return;
 
             generated_image = generated_image.split("?")[0];
-            let out_path = window.ipcRenderer.sendSync('save_dialog', '');
+            seed = seed ? seed : '0'
+            let out_path = window.ipcRenderer.sendSync('save_dialog', prompt, seed);
             if(!out_path)
                 return
 

--- a/electron_app/src/native_functions.js
+++ b/electron_app/src/native_functions.js
@@ -19,9 +19,20 @@ console.log(require('os').freemem()/(1000000000) + " Is the free memory")
 console.log(require('os').totalmem()/(1000000000) + " Is the total memory")
 
 
-ipcMain.on('save_dialog', (event, arg) => {
+ipcMain.on('save_dialog', (event, ...args) => {
 
+    const seed = args[1] ? args[1] : "0"
+    const prompt = args[0] ? args[0] : "Untitled"
+    let filename = ''
+    if (seed === '0') {
+        filename = prompt
+    } else {
+        filename = seed + '-' + prompt
+    }
+    let trimmedFilename = filename.substring(0, 254) // filename size limit
      let save_path = dialog.showSaveDialogSync({
+            title: 'Save Image',
+            defaultPath: trimmedFilename,
             filters: [{
               name: 'Image',
               extensions: ['png']


### PR DESCRIPTION
Hi!

Doing this as a lot of people where asking on Discord #beta-testing channel. I wanted it myself too. I think it is a good (although small) improvement.

There is a lot of other related things to improve but I’ve kept this PR simple in order to help and speed up the review process.

For example if the seed is 0 (default, random) it will not be included in the filename. I only worked on the front end this time.

Also, filename needed to be trunked to X characters. I used 255.

When saving image the filename suggested will be SEED - PROMPT (truncated) also for history.
<img width="525" alt="Screen Shot 2022-09-24 at 10 12 29" src="https://user-images.githubusercontent.com/147158/192073916-aae7f03a-21c8-4c4d-ad1f-c8d8d4680b9a.png">
