### PR TITLE
feat(mac): :sparkles: use quick look for image popups

### DIFF
--- a/electron_app/src/background.js
+++ b/electron_app/src/background.js
@@ -139,7 +139,6 @@ app.on('ready', async () => {
 	}
 	createWindow();
 
-	console.log(win);
 	bind_window_bridge(win);
 
 	win.webContents.on('did-finish-load', function() {

--- a/electron_app/src/components/History.vue
+++ b/electron_app/src/components/History.vue
@@ -21,7 +21,7 @@
                 
                 <div v-for="img in history_box.imgs" :key="img" class="history_box">
                     
-                    <img  @click="open_image_popup( img )"  class="gal_img" v-if="img" :src="'file://' + img" style="height:100%">
+                    <img  @click="open_image_popup({ img, title: history_box.prompt })"  class="gal_img" v-if="img" :src="'file://' + img" style="height:100%">
                     <br>
                     <div @click="save_image(img, history_box.prompt, history_box.seed)" class="l_button">Save Image</div>
                     <br>
@@ -43,8 +43,6 @@
     </div>
 </template>
 <script>
-import {open_popup} from "../utils"
-
 import Vue from 'vue'
 
 export default {
@@ -76,8 +74,8 @@ export default {
             let org_path = generated_image.replaceAll("file://" , "")
             window.ipcRenderer.sendSync('save_file', org_path+"||" +out_path);
         }, 
-        open_image_popup(img){
-            open_popup("file://"+img , undefined);
+        open_image_popup(props){
+            window.ipcRenderer.sendSync('open_popup', props);
         },
 
     },

--- a/electron_app/src/components/ImgGenerate.vue
+++ b/electron_app/src/components/ImgGenerate.vue
@@ -181,10 +181,8 @@
 
 </template>
 <script>
-
-import LoaderModal from '../components_bare/LoaderModal.vue'
-import Vue from 'vue'
-import {open_popup} from "../utils"
+import LoaderModal from "../components_bare/LoaderModal.vue";
+import Vue from "vue";
 
 export default {
     name: 'ImgGenerate',
@@ -268,13 +266,12 @@ export default {
 
             this.is_stopping = false;
 
-
            if(this.stable_diffusion)
                 this.stable_diffusion.text_to_img(params, callbacks, 'txt2img');
         } , 
 
-        open_image_popup(img){
-            open_popup("file://"+img , undefined);
+        open_image_popup(img) {
+            window.ipcRenderer.sendSync('open_popup', { img, title:this.prompt });
         },
 
         open_arthub(){

--- a/electron_app/src/native_functions.js
+++ b/electron_app/src/native_functions.js
@@ -1,9 +1,9 @@
 import { ipcMain, dialog } from 'electron'
 import { app , screen } from 'electron'
 import settings from 'electron-settings';
+import { open_popup } from './utils'
 
 var win;
-
 
 function bind_window_native_functions(w) {
     console.log("browser object binded")
@@ -262,9 +262,6 @@ ipcMain.on('show_about', (event, arg) => {
 
 })
 
-
-
-
 ipcMain.on('native_confirm', (event, arg) => {
 
     if (win) {
@@ -373,8 +370,14 @@ ipcMain.on('load_data', (event, arg) => {
 
 })
 
-
-
+ipcMain.on('open_popup', (event, { img, title }) => {
+    if (process.platform === 'darwin') {
+        win.previewFile(img, title)
+    } else {
+        open_popup("file://" + img, undefined);
+    }
+    event.returnValue = true
+})
 
 console.log("native functions imported")
 


### PR DESCRIPTION
Use system quick look to preview images instead of custom popup

<img width="819" alt="image" src="https://user-images.githubusercontent.com/244174/193075101-527b68ad-f0e4-4529-a050-b5b6e2978d3f.png">
