### PR TITLE
Allow selection of prompt in History tab

### DIFF
--- a/electron_app/src/assets/css/theme.css
+++ b/electron_app/src/assets/css/theme.css
@@ -10,6 +10,10 @@
     --menu-background: #eaebef;
 }
 
+*:focus-visible {
+    outline-color: highlight;
+}
+
 @media (prefers-color-scheme: light) {
     body {
         background-color: #F2F2F2;

--- a/electron_app/src/components/History.vue
+++ b/electron_app/src/components/History.vue
@@ -14,7 +14,7 @@
                     <span style="opacity: 0.5;" v-if="get_box_params_str(history_box)"> {{get_box_params_str(history_box)}} </span>
                     <br   v-if="get_box_params_str(history_box)">
                     
-                    <textarea v-model="history_box.prompt" rows="3" readonly class="history_box_prompt form-control"></textarea>
+                    <textarea v-model="history_box.prompt" rows="3" readonly class="history_box_prompt form-control" onfocus="this.select()"></textarea>
                 </div>
                 
                 <div v-for="img in history_box.imgs" :key="img" class="history_box">

--- a/electron_app/src/components/History.vue
+++ b/electron_app/src/components/History.vue
@@ -6,7 +6,7 @@
             <div v-for="history_box in Object.values(app_state.history).reverse()" :key="history_box.key" style="clear: both;">
             
                 <div @click="delete_hist(history_box.key)" style="float:right; margin-top: 10px;"  class="l_button">Delete</div>
-                <p class="history_box_info text_bg">
+                <div class="history_box_info text_bg">
                     <img  v-if="history_box.inp_img" :src="'file://' + history_box.inp_img" style="height:50px">
                     <br  v-if="history_box.inp_img" >
                     <br  v-if="history_box.inp_img" >
@@ -14,10 +14,8 @@
                     <span style="opacity: 0.5;" v-if="get_box_params_str(history_box)"> {{get_box_params_str(history_box)}} </span>
                     <br   v-if="get_box_params_str(history_box)">
                     
-                    {{history_box.prompt}}
-
-
-                </p>
+                    <textarea v-model="history_box.prompt" rows="3" readonly class="history_box_prompt form-control"></textarea>
+                </div>
                 
                 <div v-for="img in history_box.imgs" :key="img" class="history_box">
                     
@@ -99,17 +97,28 @@ export default {
 </style>
 <style scoped>
 .history_box_info {
-   
     padding :12px;
     border-radius: 5px;
-    max-width: calc(100vw - 200px );
+    max-width: calc(100vw - 200px);
+    margin-bottom: 16px;
 }
 
+.history_box_options {
+    margin: 0;
+}
 
+.history_box_prompt {
+    resize: none;
+    background-color: transparent;
+    width: 100%;
+    border: 0;
+    font-size: 13px;
+    padding: 0;
+}
 
 .history_box {
-    height:230px;
-    float:left;
+    height: 230px;
+    float: left;
     margin-right: 10px;
     margin-bottom: 30px;
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/714017/193493431-1836f753-b45a-4698-b708-43f93e7130b6.mov

The prompt text on the History tab is currently unselectable. That makes it challenging to reuse prompts.

This PR implements the text as a `<textarea>`, allowing selecting (but not editing). This is also the first focusable target on the page – users will now be able to <kbd>Tab</kbd> down their history. 

I kind of like being able to select fragments of previous text here. But I could see this PR being replaced by a "Copy prompt" button.

Closes #131
Closes #84

----
Quite like how that image turned out, by the way! "Cinematic digital illustration of a fearsome battle in space with a dual star system in the background"
 <img src="https://user-images.githubusercontent.com/714017/193493503-721538e6-a8e6-4183-84cb-16ac6e4f1366.png" height="250">