### PR TITLE
Added support for image generation up to 1024x1024

### DIFF
--- a/backends/stable_diffusion_tf/stable_diffusion_tf/layers.py
+++ b/backends/stable_diffusion_tf/stable_diffusion_tf/layers.py
@@ -47,5 +47,6 @@ def td_dot(a, b):
     bb = tf.reshape(b, (-1, b.shape[2], b.shape[3]))
     cc = tf.keras.backend.batch_dot(aa, bb)
     ans =  tf.reshape(cc, (-1, a.shape[1], cc.shape[1], cc.shape[2]))
-    assert ans.shape[1] * ans.shape[2] * ans.shape[3] < 8*4096*4096 - 1000 ,  "Shape too large"
+    # Gavin, 20221012: Updated from `8*4096*4096 - 1000` to `16*4096*4096 + 1` to accomodate up to 1024x1024 images
+    assert ans.shape[1] * ans.shape[2] * ans.shape[3] < 16*4096*4096 + 1 ,  "Shape too large"
     return ans

--- a/electron_app/src/components/ImgGenerate.vue
+++ b/electron_app/src/components/ImgGenerate.vue
@@ -40,6 +40,7 @@
 
                                 <b-form-group inline label=""  style="margin-bottom: 6px;">
                                     <label class="mr-sm-2" style="margin-right: 8px ;" for="inline-form-custom-select-pref">Image Height: </label>
+                                    <!-- Gavin, 20221012: Added options to accomodate up to 1024x1024 images -->
                                     <b-form-select
                                     v-model="img_h"
                                     :options="[ 64*4 , 64*5 , 64*6, 64*7 , 64*8 , 64*9 , 64*10 , 64*11 , 64*12, 64*13, 64*14, 64*15, 64*16 ]"
@@ -49,6 +50,7 @@
 
                                 <b-form-group inline label=""  style="margin-bottom: 6px;">
                                     <label class="mr-sm-2" style="margin-right: 8px ;" for="inline-form-custom-select-pref">Image Width: </label>
+                                    <!-- Gavin, 20221012: Added options to accomodate up to 1024x1024 images -->
                                     <b-form-select
                                     v-model="img_w"
                                     :options="[ 64*4 , 64*5 , 64*6, 64*7 , 64*8 , 64*9 , 64*10 , 64*11 , 64*12, 64*13, 64*14, 64*15, 64*16 ]"

--- a/electron_app/src/components/ImgGenerate.vue
+++ b/electron_app/src/components/ImgGenerate.vue
@@ -42,7 +42,7 @@
                                     <label class="mr-sm-2" style="margin-right: 8px ;" for="inline-form-custom-select-pref">Image Height: </label>
                                     <b-form-select
                                     v-model="img_h"
-                                    :options="[ 64*4 , 64*5 , 64*6, 64*7 , 64*8 , 64*9 , 64*10 , 64*11 , 64*12 ]"
+                                    :options="[ 64*4 , 64*5 , 64*6, 64*7 , 64*8 , 64*9 , 64*10 , 64*11 , 64*12, 64*13, 64*14, 64*15, 64*16 ]"
                                     required
                                     ></b-form-select>
                                 </b-form-group>
@@ -51,7 +51,7 @@
                                     <label class="mr-sm-2" style="margin-right: 8px ;" for="inline-form-custom-select-pref">Image Width: </label>
                                     <b-form-select
                                     v-model="img_w"
-                                    :options="[64*4 , 64*5 , 64*6, 64*7 , 64*8 , 64*9 , 64*10 , 64*11 , 64*12 ]"
+                                    :options="[ 64*4 , 64*5 , 64*6, 64*7 , 64*8 , 64*9 , 64*10 , 64*11 , 64*12, 64*13, 64*14, 64*15, 64*16 ]"
                                     required
                                     ></b-form-select>
                                 </b-form-group>


### PR DESCRIPTION
Added support for image generation up to 1024x1024. Reading through the comments on Issue #35, 1024x1024 seemed to be an acceptable upper bound while still generating good results (even though Stable Diffusion was trained on 512x512 images).

This was tested on a 2021 M1 MacBook Pro w/ 32GB RAM, and generating 1024x1024 images was no issue, but it is definitely slower the higher resolution you go.

Closes #35 