### PR TITLE
Fix save image path names

### DIFF
--- a/electron_app/package-lock.json
+++ b/electron_app/package-lock.json
@@ -22,6 +22,7 @@
         "electron-notarize": "^1.2.1",
         "electron-settings": "^4.0.2",
         "javascript-time-ago": "^2.3.13",
+        "truncate-utf8-bytes": "^1.0.2",
         "v-click-outside": "^3.1.2",
         "vue": "^2.6.11",
         "vue-apexcharts": "^1.6.2",
@@ -18164,7 +18165,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
-      "dev": true,
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
@@ -18829,8 +18829,7 @@
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
-      "dev": true
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
     },
     "node_modules/util": {
       "version": "0.11.1",
@@ -35770,7 +35769,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
-      "dev": true,
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
@@ -36306,8 +36304,7 @@
     "utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
-      "dev": true
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
     },
     "util": {
       "version": "0.11.1",

--- a/electron_app/package.json
+++ b/electron_app/package.json
@@ -32,6 +32,7 @@
     "electron-notarize": "^1.2.1",
     "electron-settings": "^4.0.2",
     "javascript-time-ago": "^2.3.13",
+    "truncate-utf8-bytes": "^1.0.2",
     "v-click-outside": "^3.1.2",
     "vue": "^2.6.11",
     "vue-apexcharts": "^1.6.2",

--- a/electron_app/src/components/History.vue
+++ b/electron_app/src/components/History.vue
@@ -35,7 +35,7 @@
                 
                 <div v-for="img in history_box.imgs" :key="img" class="history_box">
                 
-                    <ImageItem :app_state="app_state" :hide_extra_save_button="true" :path="img" :style_obj="{height:'100%'}"></ImageItem>
+                    <ImageItem :app_state="app_state" :hide_extra_save_button="true" :path="img" :prompt="history_box.prompt" :seed="history_box.seed" :style_obj="{height:'100%'}"></ImageItem>
                 
                 </div>
                 <div style="clear: both; display: table; margin-bottom: 10px;">

--- a/electron_app/src/components/ImageItem.vue
+++ b/electron_app/src/components/ImageItem.vue
@@ -8,7 +8,7 @@
                         <font-awesome-icon icon="bars" />
                     </div>
                 </template>
-                <b-dropdown-item-button   @click="save_image(path)"  >Save Image</b-dropdown-item-button>
+                <b-dropdown-item-button   @click="save_image(path, prompt, seed)"  >Save Image</b-dropdown-item-button>
                 <b-dropdown-item-button @click="upsclae" >Upscale Image</b-dropdown-item-button>
                 <b-dropdown-item-button @click="send_img2img" >Send to Img2Img</b-dropdown-item-button>
                 
@@ -19,7 +19,7 @@
         
         <img   @click="open_image_popup( path )"  class="gal_img" :src="'file://' + path " style="max-height: 100% ; max-width: 100%;" >
         <br>
-        <div v-if="!hide_extra_save_button" @click="save_image(path)" class="l_button">Save Image</div>
+        <div v-if="!hide_extra_save_button" @click="save_image(path, prompt, seed)" class="l_button">Save Image</div>
     </div>
 </template>
 <script>
@@ -30,6 +30,8 @@ export default {
     name: 'ImageItem',
     props: {
         path : String,
+        prompt: String,
+        seed: Number,
         style_obj:Object,
         app_state:Object,
         hide_extra_save_button : Boolean,

--- a/electron_app/src/components/ImageItem.vue
+++ b/electron_app/src/components/ImageItem.vue
@@ -1,88 +1,94 @@
 <template>
     <div style="height:100%" v-bind:style="style_obj">
-                
+
         <div v-if="!hide_dropdown" style=" position:absolute ; margin-top:7px ; margin-left:7px " class="">
             <b-dropdown left variant="link" size="sm" toggle-class="text-decoration-none" no-caret>
                 <template #button-content>
-                    <div   class=" l_button button_colored" style="background-color: rgba(0,0,0,0.6);">
+                    <div class=" l_button button_colored" style="background-color: rgba(0,0,0,0.6);">
                         <font-awesome-icon icon="bars" />
                     </div>
                 </template>
-                <b-dropdown-item-button   @click="save_image(path, prompt, seed)"  >Save Image</b-dropdown-item-button>
-                <b-dropdown-item-button @click="upsclae" >Upscale Image</b-dropdown-item-button>
-                <b-dropdown-item-button @click="send_img2img" >Send to Img2Img</b-dropdown-item-button>
-                
-                
+                <b-dropdown-item-button @click="save_image(path, prompt, seed)">Save Image</b-dropdown-item-button>
+                <b-dropdown-item-button @click="upsclae">Upscale Image</b-dropdown-item-button>
+                <b-dropdown-item-button @click="send_img2img">Send to Img2Img</b-dropdown-item-button>
             </b-dropdown>
         </div>
-        
-        
-        <img   @click="open_image_popup( path )"  class="gal_img" :src="'file://' + path " style="max-height: 100% ; max-width: 100%;" >
+
+        <img @click="open_image_popup( path )" class="gal_img" :src="'file://' + path "
+            style="max-height: 100% ; max-width: 100%;">
         <br>
         <div v-if="!hide_extra_save_button" @click="save_image(path, prompt, seed)" class="l_button">Save Image</div>
     </div>
 </template>
 <script>
 
-import {open_popup} from "../utils"
+import { open_popup } from "../utils"
 
 export default {
-    name: 'ImageItem',
+    name: "ImageItem",
     props: {
-        path : String,
+        path: String,
         prompt: String,
         seed: Number,
-        style_obj:Object,
-        app_state:Object,
-        hide_extra_save_button : Boolean,
-        hide_dropdown : Boolean,
+        style_obj: Object,
+        app_state: Object,
+        hide_extra_save_button: Boolean,
+        hide_dropdown: Boolean,
     },
     components: {},
-    mounted() {
-
-    },
+    mounted() { },
     data() {
         return {};
     },
     methods: {
-        open_image_popup(img){
-            open_popup("file://"+img , undefined);
+        open_image_popup(img) {
+            open_popup(`file://${img}`, undefined);
         },
 
-        save_image(generated_image, prompt, seed){
-            if(!generated_image)
-                return;
+        save_image(generated_image, prompt, seed) {
+            if (!generated_image) return;
             generated_image = generated_image.split("?")[0];
-            let out_path = window.ipcRenderer.sendSync('save_dialog', prompt, seed);
-            if(!out_path)
-                return
-            let org_path = generated_image.replaceAll("file://" , "")
-            window.ipcRenderer.sendSync('save_file', org_path+"||" +out_path);
+            const out_path = window.ipcRenderer.sendSync(
+                "save_dialog",
+                prompt,
+                seed
+            );
+            if (!out_path) return;
+            const org_path = generated_image.replaceAll("file://", "");
+            window.ipcRenderer.sendSync(
+                "save_file",
+                `${org_path}||${out_path}`
+            );
         },
 
-        send_img2img(){
-            if(this.app_state){
-
-                if(this.app_state.app_object.$refs.stable_diffusion.is_input_avail){
+        send_img2img() {
+            if (this.app_state) {
+                if (
+                    this.app_state.app_object.$refs.stable_diffusion
+                        .is_input_avail
+                ) {
                     this.app_state.app_object.$refs.img2img.inp_img = this.path;
-                     this.app_state.app_object.$refs.app_frame.selected_tab = 'img2img';
-                } 
+                    this.app_state.app_object.$refs.app_frame.selected_tab =
+                        "img2img";
+                }
             }
-        } , 
-
-        upsclae(){
-            if(this.app_state){
-                this.app_state.app_object.$refs.app_frame.selected_tab = 'upscale_img';
-                this.app_state.app_object.$refs.upscale_img.do_upscale(this.path);
-                
-            }
-            
         },
 
+        upsclae() {
+            if (this.app_state) {
+                this.app_state.app_object.$refs.app_frame.selected_tab =
+                    "upscale_img";
+                this.app_state.app_object.$refs.upscale_img.do_upscale(
+                    this.path
+                );
+            }
+        },
     },
-}
+};
 </script>
 <style>
+
 </style>
 <style scoped>
+
 </style>

--- a/electron_app/src/native_functions.js
+++ b/electron_app/src/native_functions.js
@@ -1,6 +1,7 @@
 import { ipcMain, dialog } from 'electron'
 import { app , screen } from 'electron'
 import settings from 'electron-settings';
+import truncate from 'truncate-utf8-bytes';
 
 var win;
 
@@ -29,10 +30,10 @@ ipcMain.on('save_dialog', (event, ...args) => {
     } else {
         filename = seed + '-' + prompt
     }
-    let trimmedFilename = filename.substring(0, 254) // filename size limit
+    const maxFilenameLength = 251; // online says 255, macOS 12 and 13 say otherwise
      let save_path = dialog.showSaveDialogSync({
             title: 'Save Image',
-            defaultPath: trimmedFilename,
+            defaultPath: truncate(filename, maxFilenameLength),
             filters: [{
               name: 'Image',
               extensions: ['png']

--- a/electron_app/src/native_functions.js
+++ b/electron_app/src/native_functions.js
@@ -20,28 +20,16 @@ console.log(require('os').freemem()/(1000000000) + " Is the free memory")
 console.log(require('os').totalmem()/(1000000000) + " Is the total memory")
 
 
-ipcMain.on('save_dialog', (event, ...args) => {
-
-    const seed = args[1] ? args[1] : "0"
-    const prompt = args[0] ? args[0] : "Untitled"
-    let filename = ''
-    if (seed === '0') {
-        filename = prompt
-    } else {
-        filename = seed + '-' + prompt
-    }
+ipcMain.on("save_dialog", (event, filename, seed) => {
     const maxFilenameLength = 251; // online says 255, macOS 12 and 13 say otherwise
-     let save_path = dialog.showSaveDialogSync({
-            title: 'Save Image',
-            defaultPath: truncate(filename, maxFilenameLength),
-            filters: [{
-              name: 'Image',
-              extensions: ['png']
-            }]
-          })
+    const save_path = dialog.showSaveDialogSync({
+        title: "Save Image",
+        defaultPath: truncate(`${seed}-${filename}`, maxFilenameLength),
+        filters: [{ name: "Image", extensions: ["png"] }],
+    });
 
-     event.returnValue = save_path;
-} )
+    event.returnValue = save_path;
+});
 
 console.log(require('os').release() + " ohoho")
 

--- a/electron_app/src/native_functions.js
+++ b/electron_app/src/native_functions.js
@@ -1,24 +1,19 @@
-import { ipcMain, dialog } from 'electron'
-import { app , screen } from 'electron'
-import settings from 'electron-settings';
-import truncate from 'truncate-utf8-bytes';
+import { ipcMain, dialog } from "electron";
+import { app, screen } from "electron";
+import settings from "electron-settings";
+import truncate from "truncate-utf8-bytes";
 
-var win;
-
+let win;
 
 function bind_window_native_functions(w) {
-    console.log("browser object binded")
+    console.log("browser object binded");
     win = w;
 }
 
+let is_windows = process.platform.startsWith("win");
 
-let is_windows = process.platform.startsWith('win');
-
-
-
-console.log(require('os').freemem()/(1000000000) + " Is the free memory")
-console.log(require('os').totalmem()/(1000000000) + " Is the total memory")
-
+console.log(`${require("os").freemem() / 1000000000} Is the free memory`);
+console.log(`${require("os").totalmem() / 1000000000} Is the total memory`);
 
 ipcMain.on("save_dialog", (event, filename, seed) => {
     const maxFilenameLength = 251; // online says 255, macOS 12 and 13 say otherwise
@@ -31,59 +26,73 @@ ipcMain.on("save_dialog", (event, filename, seed) => {
     event.returnValue = save_path;
 });
 
-console.log(require('os').release() + " ohoho")
+console.log(`${require("os").release()} ohoho`);
 
-
-
-ipcMain.on('file_dialog', (event, arg) => {
-    console.log("file dialog request recieved" + arg) // prints "ping"
+ipcMain.on("file_dialog", (event, arg) => {
+    console.log(`file dialog request recieved${arg}`); // prints "ping"
     let properties;
     let options;
 
-    if (arg == "folder") // single folder 
-    {
-        properties = ['openDirectory'];
-        options = { properties: properties } ;
-    }
-    else if(arg == 'img_file') // single image file 
-    {
-        properties = ['openFile' ]
-        options = { filters :[ {name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'bmp']}] , properties: properties } ;
-    }
-    else if(arg == 'img_files') // multi image files
-    {
-        properties = ['multiSelections' , 'openFile' ]
-        options = { filters :[ {name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'bmp']}] , properties: properties } ;
-    }
-    else if(arg == 'text_files') // multi image files
-    {
-        properties = ['multiSelections' , 'openFile' ]
-        options = { filters :[ {name: 'Images', extensions: ['txt']}] , properties: properties } ;
-    }
-    else if(arg == 'audio_files') // multi image files
-    {
-        properties = ['multiSelections' , 'openFile' ]
-        options = { filters :[ {name: 'Images', extensions: ['mp3', 'wav']}] , properties: properties } ;
-    }
-    else if(arg == 'video_files') // multi image files
-    {
-        properties = ['multiSelections' , 'openFile' ]
-        options = { filters :[ {name: 'Images', extensions: ["mp4", "mov", "avi", "flv", "wmv", "mkv"]}] , properties: properties } ;
-    }
-    else if(arg == 'any_files') // multi image files
-    {
-        properties = ['multiSelections' , 'openFile' ]
-        options = {  properties: properties } ;
-    }
-    else
-    {
-        properties = ['openFile'];
-        options = { properties: properties } ;
+    if (arg == "folder") {
+        // single folder
+        properties = ["openDirectory"];
+        options = { properties };
+    } else if (arg == "img_file") {
+        // single image file
+        properties = ["openFile"];
+        options = {
+            filters: [
+                { name: "Images", extensions: ["jpg", "jpeg", "png", "bmp"] },
+            ],
+            properties,
+        };
+    } else if (arg == "img_files") {
+        // multi image files
+        properties = ["multiSelections", "openFile"];
+        options = {
+            filters: [
+                { name: "Images", extensions: ["jpg", "jpeg", "png", "bmp"] },
+            ],
+            properties,
+        };
+    } else if (arg == "text_files") {
+        // multi image files
+        properties = ["multiSelections", "openFile"];
+        options = {
+            filters: [{ name: "Images", extensions: ["txt"] }],
+            properties,
+        };
+    } else if (arg == "audio_files") {
+        // multi image files
+        properties = ["multiSelections", "openFile"];
+        options = {
+            filters: [{ name: "Images", extensions: ["mp3", "wav"] }],
+            properties,
+        };
+    } else if (arg == "video_files") {
+        // multi image files
+        properties = ["multiSelections", "openFile"];
+        options = {
+            filters: [
+                {
+                    name: "Images",
+                    extensions: ["mp4", "mov", "avi", "flv", "wmv", "mkv"],
+                },
+            ],
+            properties,
+        };
+    } else if (arg == "any_files") {
+        // multi image files
+        properties = ["multiSelections", "openFile"];
+        options = { properties };
+    } else {
+        properties = ["openFile"];
+        options = { properties };
     }
 
     // let options = {
     //     See place holder 1 in above image
-    //     title : "Custom title bar", 
+    //     title : "Custom title bar",
     //     message : "Custom title bar",
 
     //     buttonLabel : "Custom button",
@@ -99,327 +108,274 @@ ipcMain.on('file_dialog', (event, arg) => {
     // }
 
     // //Synchronous
-    let filePaths = dialog.showOpenDialogSync(options)
+    let filePaths = dialog.showOpenDialogSync(options);
 
     if (filePaths && filePaths.length > 0)
         event.returnValue = filePaths.join(";;;");
-    else
-        event.returnValue = "NULL";
-})
+    else event.returnValue = "NULL";
+});
 
+ipcMain.on("open_url", (event, url) => {
+    let website_domain = require("../package.json").website;
+    url = url.replace("__domain__", website_domain);
+    require("electron").shell.openExternal(url);
+    event.returnValue = "";
+});
 
-
-
-ipcMain.on('open_url', (event, url) => {
-    let website_domain = require('../package.json').website ; 
-    url = url.replace("__domain__" , website_domain );
-    require('electron').shell.openExternal(url);
-    event.returnValue = '';
-})
-
-
-
-ipcMain.on('save_file', (event, arg) => {
+ipcMain.on("save_file", (event, arg) => {
     let p1 = arg.split("||")[0];
     let p2 = arg.split("||")[1];
-    require('fs').copyFileSync(p1, p2);
-    event.returnValue = '';
-})
+    require("fs").copyFileSync(p1, p2);
+    event.returnValue = "";
+});
 
-
-
-
-
-ipcMain.on('show_dialog_on_quit', (event, msg) => {
-    if(win)
-    {
+ipcMain.on("show_dialog_on_quit", (event, msg) => {
+    if (win) {
         win.show_dialog_on_quit = true;
         win.dialog_on_msg = msg;
     }
-    event.returnValue = 'ok';
+    event.returnValue = "ok";
+});
 
-})
+ipcMain.on("dont_show_dialog_on_quit", (event, arg) => {
+    if (win) win.show_dialog_on_quit = false;
+    event.returnValue = "ok";
+});
 
-
-ipcMain.on('dont_show_dialog_on_quit', (event, arg) => {
-    if(win)
-        win.show_dialog_on_quit = false;
-    event.returnValue = 'ok';
-
-})
-
-
-ipcMain.on('get_instance_id', (event, arg) => {
-    if (settings.hasSync('instance_id')){
-        event.returnValue =  settings.getSync('instance_id')
+ipcMain.on("get_instance_id", (event, arg) => {
+    if (settings.hasSync("instance_id")) {
+        event.returnValue = settings.getSync("instance_id");
         return;
     }
-    let instance_id =  (Math.random() + 1).toString(36);
-    settings.set('instance_id', instance_id);
-    event.returnValue =   instance_id;
+    let instance_id = (Math.random() + 1).toString(36);
+    settings.set("instance_id", instance_id);
+    event.returnValue = instance_id;
+});
 
-})
-
-
-ipcMain.on('unfreeze_win', (event, arg) => {
-
+ipcMain.on("unfreeze_win", (event, arg) => {
     if (win) {
-	win.savable=true;
-        const primaryDisplay = screen.getPrimaryDisplay()
-        const { width, height } = primaryDisplay.workAreaSize
+        win.savable = true;
+        const primaryDisplay = screen.getPrimaryDisplay();
+        const { width, height } = primaryDisplay.workAreaSize;
 
-        if (settings.hasSync('windowPosState')) {
-            let windowState = settings.getSync('windowPosState');
-            console.log("stateeee")
-            console.log(windowState)
+        if (settings.hasSync("windowPosState")) {
+            let windowState = settings.getSync("windowPosState");
+            console.log("stateeee");
+            console.log(windowState);
 
-            if( windowState.x  >  0.8*width ||  windowState.y  >  0.8*height ||  windowState.x  < -0.2*width || windowState.y  < -0.2*height    ){
+            if (
+                windowState.x > 0.8 * width ||
+                windowState.y > 0.8 * height ||
+                windowState.x < -0.2 * width ||
+                windowState.y < -0.2 * height
+            ) {
                 win.setSize(850, 650, false);
             } else {
-               win.setPosition( windowState.x  ,  windowState.y  , false);
-                win.setSize(windowState.width, windowState.height , false); 
+                win.setPosition(windowState.x, windowState.y, false);
+                win.setSize(windowState.width, windowState.height, false);
             }
-
-            
-        }
-        else{
+        } else {
             win.setSize(850, 650, false);
         }
 
-
         win.setResizable(true);
         win.setMaximizable(true);
-
-
-        
-        
     }
 
-    event.returnValue = 'ok';
+    event.returnValue = "ok";
+});
 
-})
-
-
-
-ipcMain.on('freeze_win', (event, arg) => {
-
+ipcMain.on("freeze_win", (event, arg) => {
     if (win) {
-	win.savable=false;
-	win.restore()
-        win.setSize(770, 550, false); 
+        win.savable = false;
+        win.restore();
+        win.setSize(770, 550, false);
         win.setResizable(false);
         win.setMaximizable(false);
 
-        const primaryDisplay = screen.getPrimaryDisplay()
+        const primaryDisplay = screen.getPrimaryDisplay();
         const { width, height } = primaryDisplay.workAreaSize;
 
-        console.log( width +" " +  height)
+        console.log(`${width} ${height}`);
 
-        win.setPosition( parseInt((width-770)/2)  , parseInt((height-550)/2), false);
-
-              
-
+        win.setPosition(
+            parseInt((width - 770) / 2),
+            parseInt((height - 550) / 2),
+            false
+        );
     }
 
-    event.returnValue = 'ok';
+    event.returnValue = "ok";
+});
 
-})
-
-
-
-ipcMain.on('show_about', (event, arg) => {
-
+ipcMain.on("show_about", (event, arg) => {
     if (win) {
-
-        if(is_windows)
-        {
-            let about_content = require('../package.json').name + "\n" + "Version " + require('../package.json').version + " (" + require('../package.json').build_number + ")\n" + require('../package.json').description;
-            const choice = require('electron').dialog.showMessageBoxSync(this, {
-                buttons: ['Okay'],
-                title: require('../package.json').name ,
-                message: about_content
+        if (is_windows) {
+            let about_content = `${require("../package.json").name}\nVersion ${require("../package.json").version
+                } (${require("../package.json").build_number})\n${require("../package.json").description
+                }`;
+            const choice = require("electron").dialog.showMessageBoxSync(this, {
+                buttons: ["Okay"],
+                title: require("../package.json").name,
+                message: about_content,
             });
+        } else {
+            app.showAboutPanel();
         }
-        else{
-            app.showAboutPanel()
-        }
-
-        
     }
 
-    event.returnValue = 'ok';
+    event.returnValue = "ok";
+});
 
-})
-
-
-
-
-ipcMain.on('native_confirm', (event, arg) => {
-
+ipcMain.on("native_confirm", (event, arg) => {
     if (win) {
-        
-        const choice = require('electron').dialog.showMessageBoxSync(this, {
-            type: 'question',
-            buttons: ['Yes', 'No'],
-            title: require('../package.json').name ,
-            message: arg
+        const choice = require("electron").dialog.showMessageBoxSync(this, {
+            type: "question",
+            buttons: ["Yes", "No"],
+            title: require("../package.json").name,
+            message: arg,
         });
         if (choice === 1) {
-            event.returnValue = false ;
+            event.returnValue = false;
+        } else {
+            event.returnValue = true;
         }
-        else{
-            event.returnValue = true ;
-        }
-
+    } else {
+        event.returnValue = false;
     }
-    else{
-        event.returnValue = false ;
-    }
+});
 
-})
-
-
-
-ipcMain.on('close_window', (event, arg) => {
-
+ipcMain.on("close_window", (event, arg) => {
     if (win) {
-        
-        win.close()
-        event.returnValue = true ;
+        win.close();
+        event.returnValue = true;
+    } else {
+        event.returnValue = false;
     }
-    else{
-        event.returnValue = false ;
-    }
+});
 
-})
-
-
-
-
-ipcMain.on('native_alert', (event, arg) => {
-
+ipcMain.on("native_alert", (event, arg) => {
     if (win) {
-        
-        const choice = require('electron').dialog.showMessageBoxSync(this, {
-            buttons: ['Okay'],
-            title: require('../package.json').name ,
-            message: arg
+        const choice = require("electron").dialog.showMessageBoxSync(this, {
+            buttons: ["Okay"],
+            title: require("../package.json").name,
+            message: arg,
         });
-        
     }
-    
-    event.returnValue = true ;
 
-})
+    event.returnValue = true;
+});
 
-
-
-
-ipcMain.on('save_b64_image', (event, arg) => {
-
-    const path = require('path');
-    const fs = require('fs');
+ipcMain.on("save_b64_image", (event, arg) => {
+    const path = require("path");
+    const fs = require("fs");
 
     let base64Data = arg.replace(/^data:image\/png;base64,/, "");
-    
-    const homedir = require('os').homedir();
-    let save_dir = path.join(homedir , ".diffusionbee")
 
+    const homedir = require("os").homedir();
+    let save_dir = path.join(homedir, ".diffusionbee");
 
-    if (!fs.existsSync(save_dir)){
+    if (!fs.existsSync(save_dir)) {
         fs.mkdirSync(save_dir, { recursive: true });
     }
 
-    save_dir = path.join(save_dir , "inp_images")
+    save_dir = path.join(save_dir, "inp_images");
 
-    if (!fs.existsSync(save_dir)){
+    if (!fs.existsSync(save_dir)) {
         fs.mkdirSync(save_dir, { recursive: true });
     }
 
-    let p = require('path').join(save_dir,  Math.random().toString()+".png");
+    let p = require("path").join(save_dir, `${Math.random().toString()}.png`);
 
-    require("fs").writeFileSync(p , base64Data, 'base64'); 
-    
-    event.returnValue = p ;
+    require("fs").writeFileSync(p, base64Data, "base64");
 
-})
+    event.returnValue = p;
+});
 
+ipcMain.on("save_data", (event, arg) => {
+    const path = require("path");
+    const fs = require("fs");
+    const homedir = require("os").homedir();
+    let save_dir = path.join(homedir, ".diffusionbee");
 
-ipcMain.on('save_data', (event, arg) => {
-    const path = require('path');
-    const fs = require('fs');
-    const homedir = require('os').homedir();
-    let save_dir = path.join(homedir , ".diffusionbee")
-
-
-    if (!fs.existsSync(save_dir)){
+    if (!fs.existsSync(save_dir)) {
         fs.mkdirSync(save_dir, { recursive: true });
     }
 
-    let data_path = path.join(homedir , ".diffusionbee" , "data.json")
-    fs.writeFileSync( data_path, JSON.stringify(arg) );
-    event.returnValue = true ;
+    let data_path = path.join(homedir, ".diffusionbee", "data.json");
+    fs.writeFileSync(data_path, JSON.stringify(arg));
+    event.returnValue = true;
+});
 
-})
+ipcMain.on("load_data", (event, arg) => {
+    const path = require("path");
+    const fs = require("fs");
+    const homedir = require("os").homedir();
+    let data_path = path.join(homedir, ".diffusionbee", "data.json");
 
-
-ipcMain.on('load_data', (event, arg) => {
-    const path = require('path');
-    const fs = require('fs');
-    const homedir = require('os').homedir();
-    let data_path = path.join(homedir , ".diffusionbee" , "data.json");
-
-    if (fs.existsSync(data_path)){
-        event.returnValue = JSON.parse(fs.readFileSync( data_path ));
+    if (fs.existsSync(data_path)) {
+        event.returnValue = JSON.parse(fs.readFileSync(data_path));
+    } else {
+        event.returnValue = {};
     }
-    else{
-        event.returnValue = {} ;
-    }       
+});
 
-})
+function run_realesrgan(input_path, cb) {
+    const path = require("path");
+    let out_path = `/tmp/${Math.random()}.png`;
+    const fs = require("fs");
+    let bin_path =
+        process.env.REALESRGAN_BIN ||
+        path.join(path.dirname(__dirname), "core", "realesrgan_ncnn_macos");
+    let weights_path = `${bin_path.replaceAll(
+        "realesrgan_ncnn_macos",
+        "models"
+    )}/`;
+    let proc = require("child_process").spawn(bin_path, [
+        "-m",
+        weights_path,
+        "-i",
+        input_path,
+        "-o",
+        out_path,
+    ]);
 
+    console.log([
+        bin_path,
+        "-m",
+        weights_path,
+        "-i",
+        input_path,
+        "-o",
+        out_path,
+    ]);
 
-
-function run_realesrgan(input_path , cb ){
-    const path = require('path');
-    let out_path = "/tmp/"+Math.random()+".png";
-    const fs = require('fs');
-    let bin_path =  process.env.REALESRGAN_BIN || path.join(path.dirname(__dirname), 'core' , 'realesrgan_ncnn_macos' );
-    let weights_path = bin_path.replaceAll("realesrgan_ncnn_macos" , "models") + "/";
-    let proc = require('child_process').spawn( bin_path  , ['-m' , weights_path , '-i' , input_path , '-o' , out_path ]);
-
-    console.log([bin_path , '-m' , weights_path , '-i' , input_path , '-o' , out_path ])
-
-    proc.stderr.on('data', (data) => {
+    proc.stderr.on("data", (data) => {
         console.error(`sr stderr: ${data}`);
     });
 
-    proc.stdout.on('data', (data) => {
+    proc.stdout.on("data", (data) => {
         console.error(`sr stderr: ${data}`);
     });
 
-    proc.on('close', (code) => {
+    proc.on("close", (code) => {
         if (fs.existsSync(out_path)) {
             cb(out_path);
-        }
-        else
-        {
-            cb('');
+        } else {
+            cb("");
         }
     });
 }
 
-ipcMain.handle('run_realesrgan', async (event, arg) => {
-    const result = await new Promise(resolve => run_realesrgan( arg , resolve));
-    return result
-})
+ipcMain.handle("run_realesrgan", async (event, arg) => {
+    const result = await new Promise((resolve) => run_realesrgan(arg, resolve));
+    return result;
+});
 
 // ipcRenderer.invoke('run_realesrgan', '/Users/divamgupta/Downloads/333.png' ).then((result) => {
 //     alert(result)
 //   })
 
+console.log("native functions imported");
 
-console.log("native functions imported")
-
-
-export { bind_window_native_functions }
+export { bind_window_native_functions };


### PR DESCRIPTION
Fixes the missing prompt and seed values in default save image boxes. Also ensures the default file name length won't be above OS restrictions, and that multibyte characters like é don't cause problems in the future with the same.

<img width="840" alt="image" src="https://user-images.githubusercontent.com/714017/195969632-a8cbb158-359d-48f0-982b-390c281cd8c2.png">


Closes #210
Closes #201
Closes #118