### PR TITLE
Fix History tab memory leak and improve History load speed by >50%

### DIFF
--- a/electron_app/src/components/History.vue
+++ b/electron_app/src/components/History.vue
@@ -5,7 +5,7 @@
           {{this.app_state.show_history_in_oldest_first ? "Oldest": "Newest"}} First
         </div>
         <div v-if="Object.values(app_state.history).length > 0">
-            <div v-for="history_box in get_history()" :key="history_box.key" style="clear: both;">
+            <div v-for="history_box in get_history()" :key="history_box.key" style="clear: both;" class="history_item">
             
                 <div @click="delete_hist(history_box.key)" style="float:right; margin-top: 10px;"  class="l_button">Delete</div>
                 <!-- <div @click="share_on_arthub(history_box)" style="float:right; margin-top: 10px;"  class="l_button">Share</div> -->
@@ -121,6 +121,12 @@ export default {
 <style>
 </style>
 <style scoped>
+.history_item {
+    contain: paint style;
+    content-visibility: auto;
+    contain-intrinsic-size: 430px;
+}
+
 .history_box_info {
    
     padding :12px;

--- a/electron_app/src/components_bare/ApplicationFrame.vue
+++ b/electron_app/src/components_bare/ApplicationFrame.vue
@@ -135,9 +135,6 @@ export default {
 
 html {
     user-select: none;
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
 }
 
 body {
@@ -253,11 +250,7 @@ h4 {
 
 img {
     user-drag: none;
-    -webkit-user-drag: none;
     user-select: none;
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
 }
 
 .animatable_content_box {
@@ -290,7 +283,6 @@ img {
     box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.16);
     border-radius: 5px;
     border: 0.5px solid rgba(0, 0, 0, 0.1);
-    /*background: #F4F5F5;*/
 }
 
 /*overriding the bootstraps dropdown highlighting*/
@@ -306,13 +298,11 @@ img {
     width: 100%;
 }
 </style>
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 .title_bar {
     height: 35px;
     width: 100%;
-    /*background: red;*/
-    -webkit-user-select: none;
+    user-select: none;
     -webkit-app-region: drag;
     border-width: 0px;
     border-bottom-width: 1px;

--- a/electron_app/src/components_bare/ApplicationFrame.vue
+++ b/electron_app/src/components_bare/ApplicationFrame.vue
@@ -30,40 +30,30 @@
         </div>
         <div class="tab_content_frame">
             <div class="tab_content">
-                
-
-                <div style="display:none"  :class="{ bl_display : selected_tab === 'txt2img'  }" >
+                <div v-show="selected_tab === 'txt2img'">
                     <slot name="txt2img"></slot>
                 </div>
 
-                <div  style="display:none"  :class="{ bl_display : selected_tab === 'img2img'  }" >
+                <div v-show="selected_tab === 'img2img'">
                     <slot name="img2img"></slot>
                 </div>
 
-                <div  v-if="selected_tab === 'history' " style="display:none"  :class="{ bl_display : selected_tab === 'history'  }" >
+                <div v-if="selected_tab === 'history'">
                     <slot name="history"></slot>
                 </div>
-                
-                
 
-                <div  style="display:none"  :class="{ bl_display : selected_tab === 'upscale_img'  }" >
+                <div v-show="selected_tab === 'upscale_img'">
                     <slot name="upscale_img"></slot>
                 </div>
 
-                <div  v-if="selected_tab === 'logs' " style="display:none"  :class="{ bl_display : selected_tab === 'logs'  }" >
+                <div v-if="selected_tab === 'logs'">
                     <slot name="logs"></slot>
                 </div>
 
-                <div v-if="selected_tab === 'outpainting' " style="display:none"  :class="{ bl_display : selected_tab === 'outpainting'  }" >
+                <div v-if="selected_tab === 'outpainting'">
                     <slot name="outpainting"></slot>
                 </div>
-
-
-
-             
             </div>
-
-
         </div>
     </div>
 </template>
@@ -139,11 +129,6 @@ html {
 body {
     font-family: var(--main-font);
 }
-
-.bl_display{
-    display:block !important;
-}
-
 
 .l_button {
     display: inline-block;

--- a/electron_app/src/components_bare/ApplicationFrame.vue
+++ b/electron_app/src/components_bare/ApplicationFrame.vue
@@ -52,7 +52,7 @@
                     <slot name="img2img"></slot>
                 </div>
 
-                <div v-if="selected_tab === 'history'">
+                <div v-show="selected_tab === 'history'">
                     <slot name="history"></slot>
                 </div>
 
@@ -60,11 +60,11 @@
                     <slot name="upscale_img"></slot>
                 </div>
 
-                <div v-if="selected_tab === 'logs'">
+                <div v-show="selected_tab === 'logs'">
                     <slot name="logs"></slot>
                 </div>
 
-                <div v-if="selected_tab === 'outpainting'">
+                <div v-show="selected_tab === 'outpainting'">
                     <slot name="outpainting"></slot>
                 </div>
             </div>

--- a/electron_app/src/components_bare/ApplicationFrame.vue
+++ b/electron_app/src/components_bare/ApplicationFrame.vue
@@ -1,32 +1,46 @@
 <template>
     <div class="main_frame">
         <div class="title_bar">
-            <div class="app_title" v-bind:class="{ 'fullscreen' :is_fullscreen||detect_windows_os() }">
-                <span @click="$emit('on_title_click',{})"> {{title}} </span>
-                <div style="float: right; margin-right: 10px; margin-top: -8.5px;" class="">
+            <div class="app_title" v-bind:class="{ fullscreen: is_fullscreen || detect_windows_os() }">
+                <span @click="$emit('on_title_click', {})"> {{ title }} </span>
+                <div style="float: right; margin-right: 10px; margin-top: -8.5px" class="">
                     <b-dropdown right variant="link" size="sm" toggle-class="text-decoration-none" no-caret>
                         <template #button-content>
                             <div style="" class="tab l_button">
                                 <font-awesome-icon icon="bars" />
                             </div>
                         </template>
-                        <b-dropdown-item-button @click="$emit('menu_item_click_help',{})">Help</b-dropdown-item-button>
-                        <b-dropdown-item-button @click="$emit('menu_item_click_discord',{})">Discord Channel</b-dropdown-item-button>
+                        <b-dropdown-item-button @click="$emit('menu_item_click_help', {})">Help</b-dropdown-item-button>
+                        <b-dropdown-item-button @click="$emit('menu_item_click_discord', {})">Discord Channel
+                        </b-dropdown-item-button>
                         <b-dropdown-item-button @click="selectTab('logs')">Show Logs</b-dropdown-item-button>
-                        <b-dropdown-item-button @click="$emit('menu_item_click_about',{})">About</b-dropdown-item-button>
-                        <b-dropdown-item-button @click="$emit('menu_item_click_close',{})">Close</b-dropdown-item-button>
+                        <b-dropdown-item-button @click="$emit('menu_item_click_about', {})">About
+                        </b-dropdown-item-button>
+                        <b-dropdown-item-button @click="$emit('menu_item_click_close', {})">Close
+                        </b-dropdown-item-button>
                         <!-- #TODO set these menu items via python -->
-                        
                     </b-dropdown>
                 </div>
                 <!-- <div style="float: right; margin-right:0" class="tab l_button"><font-awesome-icon icon="bars" /></div> -->
             </div>
         </div>
         <div class="tabs_bar">
-            <div @click="selectTab('txt2img')" class="tab l_button" v-bind:class="{ 'button_colored' : selected_tab === 'txt2img'}">Text To Image</div>
-            <div @click="selectTab('img2img')" class="tab l_button" v-bind:class="{ 'button_colored' : selected_tab === 'img2img'}">Image To Image</div>
-            <div @click="selectTab('outpainting')" class="tab l_button" v-bind:class="{ 'button_colored' : selected_tab === 'outpainting'}">Outpainting</div>
-            <div @click="selectTab('history')" class="tab l_button" v-bind:class="{ 'button_colored' : selected_tab === 'history'}">History</div>
+            <div @click="selectTab('txt2img')" class="tab l_button"
+                v-bind:class="{ button_colored: selected_tab === 'txt2img' }">
+                Text To Image
+            </div>
+            <div @click="selectTab('img2img')" class="tab l_button"
+                v-bind:class="{ button_colored: selected_tab === 'img2img' }">
+                Image To Image
+            </div>
+            <div @click="selectTab('outpainting')" class="tab l_button"
+                v-bind:class="{ button_colored: selected_tab === 'outpainting' }">
+                Outpainting
+            </div>
+            <div @click="selectTab('history')" class="tab l_button"
+                v-bind:class="{ button_colored: selected_tab === 'history' }">
+                History
+            </div>
         </div>
         <div class="tab_content_frame">
             <div class="tab_content">
@@ -61,24 +75,24 @@
 import Vue from "vue";
 
 export default {
-    name: 'ApplicationFrame',
+    name: "ApplicationFrame",
     components: {},
     props: {
         title: String,
     },
 
-    data: function() {
+    data: function () {
         return {
-            selected_tab: 'txt2img' ,
-            is_fullscreen: false ,
-        }
+            selected_tab: "txt2img",
+            is_fullscreen: false,
+        };
     },
 
     mounted() {
-        window.addEventListener('resize', this.detect_fullscreen);
+        window.addEventListener("resize", this.detect_fullscreen);
     },
     unmounted() {
-        window.removeEventListener('resize', this.detect_fullscreen);
+        window.removeEventListener("resize", this.detect_fullscreen);
     },
 
     methods: {
@@ -90,33 +104,33 @@ export default {
             this.selected_tab = tab;
         },
 
-        detect_windows_os(){
-            return window.navigator.platform.toLowerCase().startsWith('win');
+        detect_windows_os() {
+            return window.navigator.platform.toLowerCase().startsWith("win");
         },
 
-        detect_fullscreen(){
+        detect_fullscreen() {
             let that = this;
-            setTimeout(function(){
-                if ( window.innerWidth == screen.width && window.innerHeight == screen.height && (!window.screenTop && !window.screenY) )
-                    that.is_fullscreen = true ;
-                else
-                    that.is_fullscreen = false; 
-            } , 100)
-
-            
-        }
+            setTimeout(function () {
+                if (
+                    window.innerWidth == screen.width &&
+                    window.innerHeight == screen.height &&
+                    !window.screenTop &&
+                    !window.screenY
+                )
+                    that.is_fullscreen = true;
+                else that.is_fullscreen = false;
+            }, 100);
+        },
     },
-
-
-}
+};
 </script>
 <style>
-@import '../assets/css/theme.css';
+@import "../assets/css/theme.css";
+
 :root {
     --main-font: -apple-system, BlinkMacSystemFont, sans-serif;
     --main-font-text: -apple-system, BlinkMacSystemFont, sans-serif;
     /*SF Pro Text;*/
-
 }
 
 html {
@@ -141,17 +155,11 @@ body {
     font-weight: 600;
     font-size: 13px;
     line-height: 16px;
-
     text-align: center;
     letter-spacing: -0.08px;
-
     margin-right: 9px;
-
     transition: background-color 150ms ease-out 10ms, color 150ms ease-out 10ms;
 }
-
-
-
 
 .button_white {
     background-color: white;
@@ -159,7 +167,7 @@ body {
 }
 
 .button_white:hover {
-    background-color: #E0E0E0;
+    background-color: #e0e0e0;
 }
 
 .rounded_button {
@@ -167,13 +175,13 @@ body {
 }
 
 .button_colored {
-    background: #3E7BFA;
-    color: #FFFFFF;
+    background: #3e7bfa;
+    color: #ffffff;
 }
 
 .button_grey {
     background: rgba(0, 0, 0, 0.25);
-    color: #FFFFFF;
+    color: #ffffff;
 }
 
 .button_grey:hover {
@@ -192,19 +200,16 @@ body {
 }
 
 .button_color_fancy {
-
-    background: #3E7BFA;
-    color: #FFFFFF;
+    background: #3e7bfa;
+    color: #ffffff;
     height: 30px;
-    box-shadow: 0px 4px 4px #CCDDFF;
+    box-shadow: 0px 4px 4px #ccddff;
 }
 
 .button_color_fancy:hover {
-
-    background: #3E7BFA;
-    color: #FFFFFF;
-    box-shadow: 1px 1px 4px #CCDDFF;
-    ;
+    background: #3e7bfa;
+    color: #ffffff;
+    box-shadow: 1px 1px 4px #ccddff;
 }
 
 p {
@@ -217,7 +222,7 @@ p {
     letter-spacing: -0.08px;
 }
 
-.p_light{
+.p_light {
     color: rgba(0, 0, 0, 0.5);
 }
 
@@ -228,14 +233,12 @@ h1 {
     font-size: 30px;
     line-height: 38px;
     /* identical to box height, or 53% */
-
     display: flex;
     align-items: center;
     letter-spacing: -0.08px;
 }
 
 h2 {
-
     font-family: var(--main-font-text);
     font-style: normal;
     font-weight: 600;
@@ -251,16 +254,13 @@ h3 {
     font-size: 15px;
     line-height: 22px;
     /* or 107% */
-
     display: flex;
     align-items: center;
     letter-spacing: -0.08px;
-
     color: rgba(0, 0, 0, 0.9);
 }
 
-
-h4{
+h4 {
     font-family: var(--main-font-text);
     font-style: normal;
     font-weight: 600;
@@ -277,7 +277,6 @@ img {
     -ms-user-select: none;
 }
 
-
 .animatable_content_box {
     height: calc(100vh - 40px - 35px - 2px);
     position: fixed;
@@ -286,20 +285,17 @@ img {
     overflow: auto;
 }
 
-
 /*the slide transitions */
-
 .slide_show-enter-active,
 .slide_show-leave-enter {
     transform: translateX(0);
-    transition: all .25s linear;
-
+    transition: all 0.25s linear;
 }
 
 .slide_show-enter,
 .slide_show-leave-to {
     transform: translateX(100%);
-    transition: all .25s linear;
+    transition: all 0.25s linear;
 }
 
 /*overriding some styles of bootstrap dropdown*/
@@ -314,23 +310,22 @@ img {
     /*background: #F4F5F5;*/
 }
 
-.opaciy_half{
+.opaciy_half {
     opacity: 0.5;
 }
 
 /*overriding the bootstraps dropdown highlighting*/
-.btn-check:focus, .btn:focus {
+.btn-check:focus,
+.btn:focus {
     box-shadow: none !important;
 }
 
-
-.content_toolbox{
-    margin-bottom: 23px; 
+.content_toolbox {
+    margin-bottom: 23px;
     display: inline-block;
-    height: 22px; 
+    height: 22px;
     width: 100%;
 }
-
 </style>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
@@ -348,19 +343,16 @@ img {
 .app_title {
     padding-left: 80px;
     padding-top: 10px;
-
     font-family: var(--main-font-text);
     font-style: normal;
     font-weight: 600;
     font-size: 15px;
     line-height: 16px;
-
     letter-spacing: -0.08px;
-
     color: #000000;
 }
 
-.app_title.fullscreen{
+.app_title.fullscreen {
     padding-left: 22px;
 }
 
@@ -378,7 +370,6 @@ img {
     border-width: 0px;
     border-bottom-width: 1px;
     border-style: solid;
-
     padding-top: 8px;
     padding-left: 20px;
     padding-right: 20px;
@@ -386,13 +377,12 @@ img {
 
 .tab_content_frame {
     width: 100%;
-    height: calc(100vh - 40px  - 35px - 2px);
+    height: calc(100vh - 40px - 35px - 2px);
     overflow: auto;
 }
 
 .tab_content {
     /*padding: 20px;*/
-
 }
 
 .vertical-center {
@@ -404,9 +394,7 @@ img {
 }
 
 .tab {
-
     margin-right: 10px;
     cursor: pointer;
-
 }
 </style>

--- a/electron_app/src/components_bare/ApplicationFrame.vue
+++ b/electron_app/src/components_bare/ApplicationFrame.vue
@@ -68,6 +68,7 @@
     </div>
 </template>
 <script>
+import Vue from "vue";
 
 export default {
     name: 'ApplicationFrame',
@@ -92,6 +93,10 @@ export default {
 
     methods: {
         selectTab(tab) {
+            if (this.selected_tab === 'history') {
+                // drop History's images so SD can gobble up memory
+                Vue.nextTick(window.clear_cache);
+            }
             this.selected_tab = tab;
         },
 

--- a/electron_app/src/components_bare/ApplicationFrame.vue
+++ b/electron_app/src/components_bare/ApplicationFrame.vue
@@ -199,19 +199,6 @@ body {
     padding-right: 15px;
 }
 
-.button_color_fancy {
-    background: #3e7bfa;
-    color: #ffffff;
-    height: 30px;
-    box-shadow: 0px 4px 4px #ccddff;
-}
-
-.button_color_fancy:hover {
-    background: #3e7bfa;
-    color: #ffffff;
-    box-shadow: 1px 1px 4px #ccddff;
-}
-
 p {
     font-family: var(--main-font);
     font-style: normal;
@@ -220,10 +207,6 @@ p {
     line-height: 16px;
     align-items: center;
     letter-spacing: -0.08px;
-}
-
-.p_light {
-    color: rgba(0, 0, 0, 0.5);
 }
 
 h1 {
@@ -310,10 +293,6 @@ img {
     /*background: #F4F5F5;*/
 }
 
-.opaciy_half {
-    opacity: 0.5;
-}
-
 /*overriding the bootstraps dropdown highlighting*/
 .btn-check:focus,
 .btn:focus {
@@ -356,14 +335,6 @@ img {
     padding-left: 22px;
 }
 
-@media (display-mode: fullscreen) {
-    .app_title {
-        /*works in chrome but not electron*/
-        display: none;
-        background-color: red;
-    }
-}
-
 .tabs_bar {
     height: 40px;
     width: 100%;
@@ -379,18 +350,6 @@ img {
     width: 100%;
     height: calc(100vh - 40px - 35px - 2px);
     overflow: auto;
-}
-
-.tab_content {
-    /*padding: 20px;*/
-}
-
-.vertical-center {
-    margin: 0;
-    position: absolute;
-    top: 50%;
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
 }
 
 .tab {

--- a/electron_app/src/preload.js
+++ b/electron_app/src/preload.js
@@ -1,6 +1,6 @@
 // src/preload.js
 
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webFrame } from 'electron'
 
 contextBridge.exposeInMainWorld('ipcRenderer', ipcRenderer)
 contextBridge.exposeInMainWorld('ipcRenderer_on', ipcRenderer.on)
@@ -14,12 +14,12 @@ function bind_ipc_renderer_on(fn) {
 
 contextBridge.exposeInMainWorld('bind_ipc_renderer_on', bind_ipc_renderer_on)
 
-
 ipcRenderer.on("to_renderer", (e, data) => { // the msg channel which is used for electron to send msges to browser / renderer
     if (bind_ipc_renderer_on_fn)
         bind_ipc_renderer_on_fn(data)
 });
 
+contextBridge.exposeInMainWorld('clear_cache', () => webFrame.clearCache());
 
 // Expose ipcRenderer to the client ( not using it yet )
 // contextBridge.exposeInMainWorld('ipcRenderer', {


### PR DESCRIPTION
History had a memory leak, and was also very expensive to load. This PR fixes the leak, and improves repeat loads to the tab for large `data.json` instances by nearly eliminating paint times (despite worsening script times):

|  **Before** (simulated 4x CPU slowdown): 	|   **After** (simulated 4x CPU slowdown):	|
|---	|---	|
|   ![Before load times](https://user-images.githubusercontent.com/714017/196000982-8d776622-f138-46b1-a20a-de63cf33f3ba.png)	|   ![After load times](https://user-images.githubusercontent.com/714017/196001178-40315197-24d5-461e-b30e-ca7ed4db8318.png)	|

The scripting times can be solved with a proper virtualized scrolling instance.

The History tab had ever-increasing memory usage, and would actually *slow down* image generation. This is due to a few things:

1. A lot of images to load
2. A lot of components to mount
3. A lot of style calculations to make
4. `v-if` and the browser cache partition forcing images to be reacquired each time

This PR does the following:

1. Pre-render History component tree while app is booting up
2. Clears image memory when leaving the History tab
3. Reduces style calc by telling the browser we won't need paint or style calculations

----


The History view is [`v-if`](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui/blob/2abd542179d80fca806fa2900d13cd31117ea290/electron_app/src/components_bare/ApplicationFrame.vue#L43),  so its components **should** be [dropped from memory](https://vuejs.org/guide/essentials/conditional.html#v-if-vs-v-show) when hidden. That's not happening. I'm not sure why:
<img height="150" alt="image" src="https://user-images.githubusercontent.com/714017/195998474-ae6b97d3-ec8b-4424-9d51-428de0388413.png">

The `v-if` also meant that the _images_ had to be redownloaded each time, as Chromium does not cache `file://` images. For even medium histories, this balloons memory usage into the multi-gigabytes as the app is navigated around – and leaves less and less for Stable Diffusion.

Overall, `v-show` is the right move.

Fixes #199