### PR TITLE
fix(sec): upgrade tensorflow to 2.11.0

### DIFF
--- a/backends/stable_diffusion/requirements.txt
+++ b/backends/stable_diffusion/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==2.10.0
+tensorflow==2.11.0
 h5py==3.7.0
 Pillow==9.2.0
 tqdm==4.64.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tensorflow 2.10.0
- [CVE-2021-35958](https://www.oscs1024.com/hd/CVE-2021-35958)


### What did I do？
Upgrade tensorflow from 2.10.0 to 2.11.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS