### PR TITLE
feature(downloader.py): Add HTTP proxy support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -120,6 +120,18 @@ This will remove all traces of the DiffusionBee application (cache, generated im
 Open your Home folder, and press the cmd + shift + . (command + shift + period) keys. This will show the hidden files and directories. You can safely drag and drop the .diffusionbee folder in the Trash.
 
 
+## Options
+
+### Proxy Support
+Some environments may need proxy support to obtain and download models. Custom proxies can be set in DiffusionBee's config file. Just create or add the following content in:
+`~/.diffusionbee/config.ini`:
+```
+[proxy]
+host: http://localhost:8000
+```
+Afterwards, DiffusionBee will use this host as `http` and `https` proxy for downloading new models.
+
+
 ## Extra tips
 
 * For prompt ideas and help, check out:


### PR DESCRIPTION
## General
DiffusionBee may fail to download models when running in a proxy environment where:
1. ENV vars can not be evaluated due to Electron
2. Custom proxy settings may be required in general
3. A dedicated proxy should be used

This PR adds a possibility to add a config file to DiffusionBee's dot dir (`.diffusionbee/config.ini`). By section, this may be extended for additional params in future. To define a proxy, just place:
```
[proxy]
host: http://localhost:8000
```

Why ini? While other files already are json I'd really like to prefer json but writing json is not beginner and human friendly. Therefore, I'd stick to ini.

## Issue
Fixes #445 

## Ideas
This could also be added to the GUI in future to read/write settings.