### PR TITLE
refactor(real-esrgan): remove image h & w limit

### DIFF
--- a/electron_app/src/pages/PostProcessImage.vue
+++ b/electron_app/src/pages/PostProcessImage.vue
@@ -91,11 +91,6 @@ const PostProcessImage = {
             let h = this.sd_options['input_img__AUX__height' ] 
             let w = this.sd_options['input_img__AUX__width' ]
 
-            if(h > 2048 || w > 2048){
-                this.app.show_toast('Input image is too large')
-                return
-            }
-
             this.$refs.gallery.add_group({
                 group_id : 1 ,
                 num_imgs: 1 , 


### PR DESCRIPTION
I'm not really sure it makes sense to put a hard limit on the image size since real-esrgan isn't limiting iteslf. It will upscale any image just fine. An example of this can be seen in the "Upscayl" app for eg. that allows you to upscale any image size